### PR TITLE
ガントチャートで日付がnilの場合にエラーにならないようにする

### DIFF
--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -54,12 +54,12 @@
               <div class="gantt-task-content">
                 <div><%= task.name %></div>
                 <div></div>
-                <div><%= task.start_at.to_fs(:date) %></div>
-                <div><%= task.end_at.to_fs(:date) %></div>
+                <div><%= task.start_at.to_fs(:date) if task.start_at.present? %></div>
+                <div><%= task.end_at.to_fs(:date) if task.end_at.present? %></div>
               </div>
               <div class="gantt-timeline-row">
                 <div class="gantt-bar"
-                     style="<%= calculate_grid_column(@timeline_dates, task.start_at.to_date, task.end_at.to_date) %>"
+                     style="<%= calculate_grid_column(@timeline_dates, task.start_at, task.end_at) %>"
                 ></div>
               </div>
             </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -321,14 +321,14 @@ arm_breaking_project.tasks.create!(
 arm_breaking_project.tasks.create!(
   name: '設計検証',
   start_at: THIS_MONDAY.weeks_since(5),
-  end_at: THIS_FRIDAY.weeks_since(10),
+  end_at: nil,
   description: '',
   is_done: false,
   row_order: 3
 )
 arm_breaking_project.tasks.create!(
   name: 'QAへの入検',
-  start_at: THIS_MONDAY.weeks_since(11),
+  start_at: nil,
   end_at: THIS_FRIDAY.weeks_since(12),
   description: '',
   is_done: false,
@@ -336,8 +336,8 @@ arm_breaking_project.tasks.create!(
 )
 arm_breaking_project.tasks.create!(
   name: '変更連絡書の発行',
-  start_at: THIS_MONDAY.weeks_since(15),
-  end_at: THIS_FRIDAY.weeks_since(15),
+  start_at: nil,
+  end_at: nil,
   description: '',
   is_done: false,
   row_order: 5

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -3,8 +3,6 @@ FactoryBot.define do
     association :organization
 
     name { '新製品開発' }
-    is_done { false }
-    is_archived { false }
 
     trait :invalid do
       name { nil }

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -3,11 +3,6 @@ FactoryBot.define do
     association :project
 
     name { '3Dモデル設計' }
-    start_at { '2023/7/1'.to_date }
-    end_at { '2023/7/10'.to_date }
-    description { '筐体と機構を優先すること。' }
-    is_done { false }
-    row_order { nil }
 
     trait :done do
       is_done { true }

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -7,5 +7,10 @@ FactoryBot.define do
     trait :done do
       is_done { true }
     end
+
+    factory :task_with_time_span do
+      start_at { Time.zone.now }
+      end_at { start_at }
+    end
   end
 end

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -11,14 +11,16 @@ RSpec.describe "Tasks", type: :request do
 
       context '所属組織のプロジェクトの場合' do
         let(:project) { create(:project, organization: organization) }
-        let!(:task) { create(:task, project: project) }
+        let!(:task) do
+          create(:task, start_at: '2023/7/1'.to_date, end_at: '2023/7/2'.to_date, project: project)
+        end
 
         before { get project_tasks_path(project) }
 
         it 'タスク情報を取得できること' do
           expect(response.body).to include task.name
-          expect(response.body).to include task.start_at.to_fs(:date)
-          expect(response.body).to include task.end_at.to_fs(:date)
+          expect(response.body).to include '2023/7/1'
+          expect(response.body).to include '2023/7/2'
         end
       end
 

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Tasks', type: :system do
   describe 'プロジェクトタスク一覧ページ' do
     let(:project) { create(:project, organization: user.organization) }
 
-    describe 'プロジェクト情報' do
+    describe 'プロジェクト' do
       before { visit project_tasks_path(project) }
 
       it '指定したプロジェクト名が表示されていること' do
@@ -18,14 +18,38 @@ RSpec.describe 'Tasks', type: :system do
       end
     end
 
-    describe 'タスク情報' do
-      let!(:task) { create(:task, :done, project: project) }
+    describe 'タスク' do
+      describe 'ガントバー' do
+        context 'タスク期間が指定されている場合' do
+          let!(:task) { create(:task_with_time_span, project: project) }
 
-      before { visit project_tasks_path(project) }
+          before { visit project_tasks_path(project) }
 
-      it '完了タスクがグレーアウトされていること' do
-        within '.gantt-tasks' do
-          expect(page).to have_css '.done-task'
+          it '表示されていること' do
+            expect(find('.gantt-bar')).to be_visible
+          end
+        end
+
+        context 'タスク期間が欠落している場合' do
+          let!(:task) { create(:task, project: project) }
+
+          before { visit project_tasks_path(project) }
+
+          it '非表示になっていること' do
+            expect(find('.gantt-bar', visible: false)).not_to be_visible
+          end
+        end
+      end
+
+      describe '完了状態' do
+        let!(:task) { create(:task, :done, project: project) }
+
+        before { visit project_tasks_path(project) }
+
+        it '完了タスクがグレーアウトされていること' do
+          within '.gantt-tasks' do
+            expect(page).to have_css '.done-task'
+          end
         end
       end
     end


### PR DESCRIPTION
## Issue または変更目的
close #57 

## 変更内容
- [x] タスクの日付にnilを含むものがあるようseedを変更する。
- [x] タスク一覧ページで、タスクの日付がnilかどうかで条件分岐を加える。
- [x] 大元のfactoryの定義を必要最低限にする。

## 確認手順
<!--仕様やテストがあるならその旨を記載すれば十分-->
テストを参照のこと。
または、`/projects/5/tasks`を参照のこと。
