### PR TITLE
本番環境で新規ユーザーを招待できるようにする

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: bin/rails db:migrate
 web: bundle exec puma -C config/puma.rb

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
-  # config.require_master_key = true
+  config.require_master_key = true
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.


### PR DESCRIPTION
## Issue または変更目的
close #63 

## 変更内容

- [x] Procfileにおいて、サーバー起動前に`release: bin/rails db:migrate`という文を追加する。これにより、deploy時に自動でmigrateするようにする。
- [x] ``heroku config:set RAILS_MASTER_KEY=`cat config/master.key` ``を実行し、herokuの環境変数にmaster keyを追加する。
- [x] `config/environments/production.rb`にて、`config.require_master_key = true`にし、master keyがないとRailsアプリが起動しないよう設定する。

## 確認手順
<!--仕様やテストがあるならその旨を記載すれば十分-->
- [x] `heroku run bin/rails db:rollback`を実行しておく。
- [x] herokuにこのブランチをdeployし、master keyが必要と警告が出てdeployが失敗することを確認する。
- [x] herokuにmaster keyを追加すると、問題なくdeployでき、その際に自動でmigrateされることを確認する。
- [x] 新規ユーザーを招待できることを確認する。
