### PR TITLE
タスク登録機能の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,9 @@ gem "devise-i18n"
 
 gem 'devise_invitable'
 
+# 並び替え機能を提供
+gem 'ranked-model'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i(mri mingw x64_mingw)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,6 +207,8 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
+    ranked-model (0.4.9)
+      activerecord (>= 5.2)
     regexp_parser (2.7.0)
     reline (0.3.3)
       io-console (~> 0.5)
@@ -330,6 +332,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.0.4, >= 7.0.4.3)
   rails-i18n
+  ranked-model
   rspec-rails
   rubocop-airbnb
   selenium-webdriver

--- a/app.json
+++ b/app.json
@@ -1,0 +1,40 @@
+{
+  "name": "taskwith",
+  "scripts": {
+    "postdeploy": "bundle exec rake db:schema:load db:seed"
+  },
+  "env": {
+    "DISABLE_DATABASE_ENVIRONMENT_CHECK": {
+      "value": "1"
+    },
+    "LANG": {
+      "value": "en_US.UTF-8"
+    },
+    "RACK_ENV": {
+      "value": "production"
+    },
+    "RAILS_ENV": {
+      "value": "production"
+    },
+    "RAILS_LOG_TO_STDOUT": {
+      "value": "enabled"
+    },
+    "RAILS_SERVE_STATIC_FILES": {
+      "value": "enabled"
+    }
+  },
+  "formation": {
+    "web": {
+      "quantity": 1
+    }
+  },
+  "addons": [
+    "jawsdb"
+  ],
+  "buildpacks": [
+    {
+      "url": "heroku/ruby"
+    }
+  ],
+  "stack": "heroku-22"
+}

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -9,9 +9,8 @@ class ProjectsController < ApplicationController
   end
 
   def create
-    @project = Project.new(
+    @project = current_user.organization.projects.new(
       **params.require(:project).permit(:name, :description, :is_done, :is_archived),
-      organization: current_user.organization,
       users: [current_user]
     )
     if @project.save

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,18 +2,37 @@ class TasksController < ApplicationController
   before_action :block_user_belongs_to_other_organization
 
   def index
-    @project = Project.find(params[:project_id])
     @tasks = @project.tasks.order(:row_order)
 
     @today = Time.zone.today
     @timeline_dates = create_timeline_dates(@today, 3)
   end
 
+  def new
+    @task = @project.tasks.new
+  end
+
+  def create
+    @task = @project.tasks.new(
+      params.require(:task).permit(:name, :start_at, :end_at, :description)
+    )
+    if @task.save
+      flash[:notice] = 'タスクを作成しました。'
+      redirect_to project_tasks_path(@project)
+    else
+      flash.now[:alert] = 'タスクを作成できませんでした。'
+      render 'new', status: :unprocessable_entity
+    end
+  end
+
   private
 
   def block_user_belongs_to_other_organization
-    if Project.find(params[:project_id]).organization != current_user.organization
-      redirect_to projects_path
+    if action_name.start_with?(*%w(index new create))
+      @project = Project.find(params[:project_id])
+      if @project.organization != current_user.organization
+        redirect_to projects_path
+      end
     end
   end
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,5 +1,9 @@
 class Task < ApplicationRecord
+  include RankedModel
+
   belongs_to :project
+  ranks :row_order,
+    with_same: :project_id # projectごとにscopeを絞ってランク付け
 
   validates :name, presence: true
   validate :check_period

--- a/app/views/organizations/new.html.erb
+++ b/app/views/organizations/new.html.erb
@@ -11,7 +11,8 @@
       <%= form_with model: @organization, class: "p-4 p-md-5 border rounded-3 bg-light" do |f| %>
         <%= render "shared/error_messages", object: @organization %>
         <div class="mb-3">
-          <%= f.label :name, class: "form-label" %><br />
+          <%= f.label :name, class: "form-label" %>
+          <span class="badge bg-danger form-label">必須</span><br>
           <%= f.text_field :name, placeholder: "〇〇株式会社、プライベート", class: "form-control", autofocus: true %>
         </div>
         <div>

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -3,11 +3,12 @@
   <%= form_with model: @project do |f| %>
     <%= render "shared/error_messages", object: @project %>
     <div>
-      <%= f.label :name %><br />
+      <%= f.label :name %>
+      <span class="badge bg-danger">必須</span><br>
       <%= f.text_field :name, autofocus: true %>
     </div>
     <div>
-      <%= f.label :description %><br />
+      <%= f.label :description %><br>
       <%= f.text_area :description %>
     </div>
     <div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -12,7 +12,11 @@
          data-gantt-chart-target="chart">
       <div class="gantt-header gantt-row">
         <div class="gantt-task-header">
-          <div><%= t('activerecord.attributes.task.name') %></div>
+          <div class="position-relative">
+            <%= t('activerecord.attributes.task.name') %>
+            <%= link_to "+", new_project_task_path,
+                class: 'btn btn-primary position-absolute bottom-0 end-0 mb-1 me-1 px-2 py-0' %>
+          </div>
           <div>担当者</div>
           <div><%= t('activerecord.attributes.task.start_at') %></div>
           <div><%= t('activerecord.attributes.task.end_at') %></div>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -3,7 +3,8 @@
   <%= form_with model: [@project, @task] do |f| %>
     <%= render "shared/error_messages", object: @task %>
     <div>
-      <%= f.label :name %><br>
+      <%= f.label :name %>
+      <span class="badge bg-danger">必須</span><br>
       <%= f.text_field :name, autofocus: true %>
     </div>
     <div>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,0 +1,26 @@
+<div class="container">
+  <h1 class="mt-5">新規タスク作成</h1>
+  <%= form_with model: [@project, @task] do |f| %>
+    <%= render "shared/error_messages", object: @task %>
+    <div>
+      <%= f.label :name %><br>
+      <%= f.text_field :name, autofocus: true %>
+    </div>
+    <div>
+      <%= f.label :start_at %><br>
+      <%= f.date_field :start_at %>
+    </div>
+    <div>
+      <%= f.label :end_at %><br>
+      <%= f.date_field :end_at %>
+    </div>
+    <div>
+      <%= f.label :description %><br>
+      <%= f.text_area :description %>
+    </div>
+    <div>
+      <%= f.submit "作成" %>
+    </div>
+  <% end %>
+  <%= link_to "戻る", :back %>
+</div>

--- a/app/views/users/invitations/edit.html.erb
+++ b/app/views/users/invitations/edit.html.erb
@@ -10,16 +10,19 @@
   <% if f.object.class.require_password_on_accepting %>
     <div class="field">
       <%= f.label :name %>
+      <span class="badge bg-danger">必須</span><br>
       <%= f.text_field :name %>
     </div>
 
     <div class="field">
-      <%= f.label :password %><br />
+      <%= f.label :password %>
+      <span class="badge bg-danger">必須</span><br>
       <%= f.password_field :password %>
     </div>
 
     <div class="field">
-      <%= f.label :password_confirmation %><br />
+      <%= f.label :password_confirmation %>
+      <span class="badge bg-danger">必須</span><br>
       <%= f.password_field :password_confirmation %>
     </div>
   <% end %>

--- a/app/views/users/invitations/new.html.erb
+++ b/app/views/users/invitations/new.html.erb
@@ -5,7 +5,8 @@
 
   <% resource.class.invite_key_fields.each do |field| -%>
     <div class="field">
-      <%= f.label field %><br />
+      <%= f.label field %>
+      <span class="badge bg-danger">必須</span><br>
       <%= f.text_field field %>
     </div>
   <% end -%>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -2,22 +2,26 @@
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <%= render "users/shared/error_messages", resource: resource %>
   <div class="field">
-    <%= f.label :name %><br />
+    <%= f.label :name %>
+    <span class="badge bg-danger">必須</span><br>
     <%= f.text_field :name, autofocus: true, autocomplete: "name" %>
   </div>
   <div class="field">
-    <%= f.label :email %><br />
+    <%= f.label :email %>
+    <span class="badge bg-danger">必須</span><br>
     <%= f.email_field :email, autocomplete: "email" %>
   </div>
   <div class="field">
     <%= f.label :password %>
     <% if @minimum_password_length %>
     <em><%= t('users.shared.minimum_password_length', count: @minimum_password_length) %></em>
-    <% end %><br />
+    <% end %>
+    <span class="badge bg-danger">必須</span><br>
     <%= f.password_field :password, autocomplete: "new-password" %>
   </div>
   <div class="field">
-    <%= f.label :password_confirmation %><br />
+    <%= f.label :password_confirmation %>
+    <span class="badge bg-danger">必須</span><br>
     <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
   </div>
   <div class="actions">

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -2,12 +2,14 @@
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
-    <%= f.label :email %><br />
+    <%= f.label :email %>
+    <span class="badge bg-danger">必須</span><br>
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
 
   <div class="field">
-    <%= f.label :password %><br />
+    <%= f.label :password %>
+    <span class="badge bg-danger">必須</span><br>
     <%= f.password_field :password, autocomplete: "current-password" %>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,18 +1,21 @@
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
-  root 'home#index'
-  resources :home, only: :index
+  shallow do
+    root 'home#index'
+    resources :home, only: :index
 
-  devise_for :users, controllers: { invitations: 'users/invitations' }
+    devise_for :users, controllers: { invitations: 'users/invitations' }
 
-  resource :organization
+    resource :organization
+
+    namespace :projects do
+      resources :archived, only: :index
+    end
+    resources :projects do
+      resources :tasks
+    end
+  end
+
   resolve('Organization') { [:organization] } # 単数形リソースでform_withを機能させるため
-
-  namespace :projects do
-    resources :archived, only: :index
-  end
-  resources :projects do
-    resources :tasks
-  end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -152,7 +152,6 @@ noise_reduction_project.tasks.create!(
   end_at: nil,
   description: '',
   is_done: false,
-  row_order: 1
 )
 
 product_development_project.tasks.create!(
@@ -161,7 +160,6 @@ product_development_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(1),
   description: '筐体と機構を優先すること。',
   is_done: true,
-  row_order: 1
 )
 product_development_project.tasks.create!(
   name: '図面作成',
@@ -169,7 +167,6 @@ product_development_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_since(1),
   description: '',
   is_done: false,
-  row_order: 2
 )
 product_development_project.tasks.create!(
   name: '部品手配',
@@ -177,7 +174,6 @@ product_development_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_since(1),
   description: '4台分手配。手配可能なものがあれば順次手配する。',
   is_done: false,
-  row_order: 3
 )
 product_development_project.tasks.create!(
   name: '組立',
@@ -185,7 +181,6 @@ product_development_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_since(7),
   description: '',
   is_done: false,
-  row_order: 4
 )
 product_development_project.tasks.create!(
   name: '設計検証',
@@ -193,7 +188,6 @@ product_development_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_since(11),
   description: '',
   is_done: false,
-  row_order: 5
 )
 product_development_project.tasks.create!(
   name: 'QAへの入検',
@@ -201,7 +195,6 @@ product_development_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_since(15),
   description: '',
   is_done: false,
-  row_order: 6
 )
 
 safety_regulations_project.tasks.create!(
@@ -210,7 +203,6 @@ safety_regulations_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(8),
   description: '',
   is_done: true,
-  row_order: 1
 )
 safety_regulations_project.tasks.create!(
   name: '3Dモデル設計',
@@ -218,7 +210,6 @@ safety_regulations_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(6),
   description: '',
   is_done: true,
-  row_order: 2
 )
 safety_regulations_project.tasks.create!(
   name: '図面作成',
@@ -226,7 +217,6 @@ safety_regulations_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(5),
   description: '',
   is_done: true,
-  row_order: 3
 )
 safety_regulations_project.tasks.create!(
   name: '部品手配',
@@ -234,7 +224,6 @@ safety_regulations_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(5),
   description: '',
   is_done: true,
-  row_order: 4
 )
 safety_regulations_project.tasks.create!(
   name: '設計検証',
@@ -242,7 +231,6 @@ safety_regulations_project.tasks.create!(
   end_at: THIS_FRIDAY,
   description: '',
   is_done: false,
-  row_order: 5
 )
 safety_regulations_project.tasks.create!(
   name: 'QAへの入検',
@@ -250,7 +238,6 @@ safety_regulations_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_since(1),
   description: '',
   is_done: false,
-  row_order: 6
 )
 safety_regulations_project.tasks.create!(
   name: '変更連絡書の発行',
@@ -258,7 +245,6 @@ safety_regulations_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_since(3),
   description: '',
   is_done: false,
-  row_order: 7
 )
 
 cable_disconnection_project.tasks.create!(
@@ -267,7 +253,6 @@ cable_disconnection_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(14),
   description: '',
   is_done: true,
-  row_order: 1
 )
 cable_disconnection_project.tasks.create!(
   name: '試作手配',
@@ -275,7 +260,6 @@ cable_disconnection_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(13),
   description: '',
   is_done: true,
-  row_order: 2
 )
 cable_disconnection_project.tasks.create!(
   name: '設計検証',
@@ -283,7 +267,6 @@ cable_disconnection_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(6),
   description: '',
   is_done: true,
-  row_order: 3
 )
 cable_disconnection_project.tasks.create!(
   name: 'QAへの入検',
@@ -291,7 +274,6 @@ cable_disconnection_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(5),
   description: '',
   is_done: true,
-  row_order: 4
 )
 cable_disconnection_project.tasks.create!(
   name: '変更連絡書の発行',
@@ -299,7 +281,6 @@ cable_disconnection_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(3),
   description: '',
   is_done: true,
-  row_order: 5
 )
 
 arm_breaking_project.tasks.create!(
@@ -308,7 +289,6 @@ arm_breaking_project.tasks.create!(
   end_at: THIS_FRIDAY,
   description: '',
   is_done: false,
-  row_order: 1
 )
 arm_breaking_project.tasks.create!(
   name: '試作手配',
@@ -316,7 +296,6 @@ arm_breaking_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_since(1),
   description: '',
   is_done: false,
-  row_order: 2
 )
 arm_breaking_project.tasks.create!(
   name: '設計検証',
@@ -324,7 +303,6 @@ arm_breaking_project.tasks.create!(
   end_at: nil,
   description: '',
   is_done: false,
-  row_order: 3
 )
 arm_breaking_project.tasks.create!(
   name: 'QAへの入検',
@@ -332,7 +310,6 @@ arm_breaking_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_since(12),
   description: '',
   is_done: false,
-  row_order: 4
 )
 arm_breaking_project.tasks.create!(
   name: '変更連絡書の発行',
@@ -340,7 +317,6 @@ arm_breaking_project.tasks.create!(
   end_at: nil,
   description: '',
   is_done: false,
-  row_order: 5
 )
 
 sensor_false_detection_project.tasks.create!(
@@ -349,7 +325,6 @@ sensor_false_detection_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(12),
   description: '',
   is_done: true,
-  row_order: 1
 )
 sensor_false_detection_project.tasks.create!(
   name: '試作手配',
@@ -357,7 +332,6 @@ sensor_false_detection_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(11),
   description: '',
   is_done: true,
-  row_order: 2
 )
 sensor_false_detection_project.tasks.create!(
   name: '設計検証',
@@ -365,7 +339,6 @@ sensor_false_detection_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(4),
   description: '',
   is_done: true,
-  row_order: 3
 )
 sensor_false_detection_project.tasks.create!(
   name: 'QAへの入検',
@@ -373,7 +346,6 @@ sensor_false_detection_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(3),
   description: '',
   is_done: true,
-  row_order: 4
 )
 sensor_false_detection_project.tasks.create!(
   name: '変更連絡書の発行',
@@ -381,7 +353,6 @@ sensor_false_detection_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(1),
   description: '',
   is_done: true,
-  row_order: 5
 )
 
 # 神奈川製鉄株式会社
@@ -391,7 +362,6 @@ material_research_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_since(8),
   description: '',
   is_done: false,
-  row_order: 1
 )
 car_frame_project.tasks.create!(
   name: '抗酸化皮膜の耐久試験',
@@ -399,5 +369,4 @@ car_frame_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(1),
   description: '',
   is_done: true,
-  row_order: 1
 )

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -4,6 +4,10 @@ FactoryBot.define do
 
     name { '3Dモデル設計' }
 
+    trait :invalid do
+      name { nil }
+    end
+
     trait :done do
       is_done { true }
     end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe "Projects", type: :request do
         end
 
         it '表示中のプロジェクトの数量を取得できること' do
-          expect(response.body).to include "#{Project.where(is_archived: false).count}件のプロジェクトを表示中"
+          expect(response.body).
+            to include "#{organization.projects.where(is_archived: false).count}件のプロジェクトを表示中"
         end
       end
 
@@ -72,21 +73,21 @@ RSpec.describe "Projects", type: :request do
       context '有効な属性値の場合' do
         let(:project_attributes) { attributes_for(:project) }
 
-        it 'プロジェクトを作成できること' do
+        it '所属組織のプロジェクトを作成できること' do
           expect do
             post projects_path, params: { project: project_attributes }
-          end.to change { user.projects.count }.by(1)
-          expect(Project.last.organization).to eq user.organization
+          end.to change { user.organization.projects.count }.by(1)
+          expect(user.organization.projects.last.users).to eq [user]
         end
       end
 
       context '無効な属性値の場合' do
         let(:project_attributes) { attributes_for(:project, :invalid) }
 
-        it 'プロジェクトを作成できないこと' do
+        it '所属組織のプロジェクトを作成できないこと' do
           expect do
             post projects_path, params: { project: project_attributes }
-          end.not_to change { user.projects.count }
+          end.not_to change { user.organization.projects.count }
           expect(response).to have_http_status :unprocessable_entity
         end
       end
@@ -98,7 +99,7 @@ RSpec.describe "Projects", type: :request do
       it 'プロジェクトが作成されず、組織作成ページにリダイレクトされること' do
         expect do
           post projects_path, params: { project: project_attributes }
-        end.not_to change { user.projects.count }
+        end.not_to change { Project.count }
         expect(response).to redirect_to new_organization_path
       end
     end

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe "Tasks", type: :request do
+  let(:user) { create(:user) }
+
+  before { sign_in user }
+
   describe "GET /projects/:project_id/tasks" do
-    let(:user) { create(:user) }
-
-    before { sign_in user }
-
     context 'ユーザーが組織に所属している場合' do
       let!(:organization) { create(:organization, users: [user]) }
 
@@ -41,6 +41,85 @@ RSpec.describe "Tasks", type: :request do
       before { get project_tasks_path(project) }
 
       it '組織作成ページにリダイレクトされること' do
+        expect(response).to redirect_to new_organization_path
+      end
+    end
+  end
+
+  describe "GET /projects/:project_id/tasks/new" do
+    context 'ユーザーが組織に所属している場合' do
+      let(:organization) { create(:organization, users: [user]) }
+      let(:project) { create(:project, organization: organization) }
+
+      before { get new_project_task_path(project) }
+
+      it 'タスク作成ページにアクセスできること' do
+        expect(response).to have_http_status 200
+        expect(response.body).to include '新規タスク作成'
+      end
+    end
+
+    context 'ユーザーが組織に所属していない場合' do
+      let(:project) { create(:project) }
+
+      before { get new_project_task_path(project) }
+
+      it '組織作成ページにリダイレクトされること' do
+        expect(response).to redirect_to new_organization_path
+      end
+    end
+  end
+
+  describe "POST /projects/:project_id/tasks" do
+    context 'ユーザーが組織に所属している場合' do
+      let!(:organization) { create(:organization, users: [user]) }
+
+      context '所属組織のプロジェクトの場合' do
+        let(:project) { create(:project, organization: organization) }
+
+        context '有効な属性値の場合' do
+          let(:task_attributes) { attributes_for(:task) }
+
+          it 'タスクを作成できること' do
+            expect do
+              post project_tasks_path(project), params: { task: task_attributes }
+            end.to change { project.tasks.count }.by(1)
+          end
+        end
+
+        context '無効な属性値の場合' do
+          let(:task_attributes) { attributes_for(:task, :invalid) }
+
+          it 'タスクを作成できないこと' do
+            expect do
+              post project_tasks_path(project), params: { task: task_attributes }
+            end.not_to change { project.tasks.count }
+            expect(response).to have_http_status :unprocessable_entity
+          end
+        end
+      end
+
+      context '他の組織のプロジェクトの場合' do
+        let(:project) { create(:project) }
+        let(:task_attributes) { attributes_for(:task) }
+
+        it 'タスクが作成されず、プロジェクト一覧ページにリダイレクトされること' do
+          expect do
+            post project_tasks_path(project), params: { task: task_attributes }
+          end.not_to change { project.tasks.count }
+          expect(response).to redirect_to projects_path
+        end
+      end
+    end
+
+    context 'ユーザーが組織に所属していない場合' do
+      let(:project) { create(:project) }
+      let(:task_attributes) { attributes_for(:task) }
+
+      it 'タスクが作成されず、組織作成ページにリダイレクトされること' do
+        expect do
+          post project_tasks_path(project), params: { task: task_attributes }
+        end.not_to change { project.tasks.count }
         expect(response).to redirect_to new_organization_path
       end
     end

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -84,6 +84,7 @@ RSpec.describe "Tasks", type: :request do
             expect do
               post project_tasks_path(project), params: { task: task_attributes }
             end.to change { project.tasks.count }.by(1)
+            expect(project.tasks.last.row_order).to be_truthy
           end
         end
 

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -54,4 +54,25 @@ RSpec.describe 'Tasks', type: :system do
       end
     end
   end
+
+  describe 'タスク登録機能' do
+    let(:project) { create(:project, organization: user.organization) }
+    let(:task) { build(:task) }
+
+    it 'タスクを登録できること' do
+      visit project_tasks_path(project)
+      click_on '+'
+
+      expect(current_path).to eq new_project_task_path(project)
+
+      expect do
+        fill_in 'task[name]', with: task.name
+        click_on '作成'
+      end.to change { project.tasks.count }.by(1)
+
+      expect(current_path).to eq project_tasks_path(project)
+      expect(page).to have_content 'タスクを作成しました。'
+      expect(page).to have_content task.name
+    end
+  end
 end


### PR DESCRIPTION
## Issue または変更目的
close #24 

## 変更内容
- [x] タスク登録機能を追加する。
- [x] ranked-model gemを適用し、タスク登録時にrow-orderが設定されるようにする。
- [x] formに必須のバッジを追加する。
- [x] PRのマージ前に、本番環境とは別の環境でproductionモードにてアプリの動作を手動でテストできるよう、Herokuのレビューアプリを設定する。

## 確認手順
<!--仕様やテストがあるならその旨を記載すれば十分-->
テストを参照のこと。
