### PR TITLE
フィッシングの阻止

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
   validates :name, presence: true
 
   # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  # :confirmable, :lockable, :trackable and :omniauthable
   devise :invitable, :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable, :timeoutable
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
     <title>TaskWith</title>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+    <meta name="google-site-verification" content="Y8MsLvXwGv3_bXwwGik3nWFLvm_6Q88OHjqq_wozzZw" />
   </head>
   <body class="d-flex flex-column min-vh-100">
     <%= render 'shared/header' %>

--- a/app/views/projects/archived/index.html.erb
+++ b/app/views/projects/archived/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <h1 class="mt-5">アーカイブ済みのプロジェクト一覧</h1>
   <div class="d-flex justify-content-end">
-    <%= link_to "戻る", :back %>
+    <%= link_to "戻る", 'javascript:history.back()' %>
   </div>
   <div class="row justify-content-center">
     <div class="table-responsive col-lg-8">

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -15,5 +15,5 @@
       <%= f.submit "作成" %>
     </div>
   <% end %>
-  <%= link_to "戻る", :back %>
+  <%= link_to "戻る", 'javascript:history.back()' %>
 </div>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -23,5 +23,5 @@
       <%= f.submit "作成" %>
     </div>
   <% end %>
-  <%= link_to "戻る", :back %>
+  <%= link_to "戻る", 'javascript:history.back()' %>
 </div>

--- a/app/views/users/invitations/new.html.erb
+++ b/app/views/users/invitations/new.html.erb
@@ -14,4 +14,5 @@
   <div class="actions">
     <%= f.submit t("users.invitations.new.submit_button") %>
   </div>
+  <%= link_to "戻る", 'javascript:history.back()' %>
 <% end %>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -40,4 +40,4 @@
 
 <div><%= t('.unhappy') %> <%= button_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure'), turbo_confirm: t('.are_you_sure') }, method: :delete %></div>
 
-<%= link_to t('users.shared.links.back'), :back %>
+<%= link_to t('users.shared.links.back'), 'javascript:history.back()' %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -237,7 +237,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = 1.day
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.


### PR DESCRIPTION
## Issue または変更目的
close #66 

## 変更内容
- [x] googleのsearch consoleを使用するため、サイト所有権を確認するmetaタグをhead内に追加する。
- [x] link_toにて、`:back`ではなく`'javascript:history.back()'`を使用する。
- [x] セキュリティ強化のため、セッション持続時間を設定する。

※`/projects/:project_id/tasks`については原因が不明なため、search consoleでの再審査の結果を待ってなお解決していなければ、対応を考える。

## 確認手順
<!--仕様やテストがあるならその旨を記載すれば十分-->
- [x] リロードしても、戻るリンクに遷移元サイトのURLが入らず、1つ前のページに戻ることができることを確認する。

## マージ後の作業

- [ ] 本番環境へのデプロイが確認できたら、search consoleにて再審査をリクエストする。