### PR TITLE
タスク編集機能の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,9 @@ gem 'devise_invitable'
 # 並び替え機能を提供
 gem 'ranked-model'
 
+# JSにおいて、Railsアプリケーションに必要なヘッダーを加えたHTTPリクエストを送信する機能を提供する
+gem 'requestjs-rails'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i(mri mingw x64_mingw)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,6 +212,8 @@ GEM
     regexp_parser (2.7.0)
     reline (0.3.3)
       io-console (~> 0.5)
+    requestjs-rails (0.0.10)
+      rails (>= 6.0.0)
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
@@ -333,6 +335,7 @@ DEPENDENCIES
   rails (~> 7.0.4, >= 7.0.4.3)
   rails-i18n
   ranked-model
+  requestjs-rails
   rspec-rails
   rubocop-airbnb
   selenium-webdriver

--- a/app/assets/stylesheets/custom/gantt_chart.scss
+++ b/app/assets/stylesheets/custom/gantt_chart.scss
@@ -33,13 +33,12 @@ main:has(.gantt-chart) {
 .gantt-task-header,
 .gantt-task-content {
   @extend .d-grid;
-  @extend .bg-white;
   @extend .position-sticky;
   @extend .start-0;
   grid-template-columns: 2fr 1fr 80px 80px;
   border-right: 1px solid var(--bs-gray-300);
   border-bottom: 1px solid var(--bs-gray-300);
-  z-index: 3;
+  z-index: 1;
 
   &>div {
     @extend .d-grid;
@@ -51,8 +50,15 @@ main:has(.gantt-chart) {
     }
   }
 }
-.gantt-task-content>div:first-child {
-  place-items: center start;
+.gantt-task-header {
+  background-color: var(--bs-gray-200);
+}
+.gantt-task-content {
+  @extend .bg-white;
+
+  &>div:first-child {
+    place-items: center start;
+  }
 }
 .gantt-scale-header {
   @extend .d-none;
@@ -70,6 +76,9 @@ main:has(.gantt-chart) {
   @extend .d-grid;
   place-items: center;
   border-right: 1px dotted var(--bs-gray-300);
+}
+.gantt-months>div:nth-child(odd) {
+  background-color: var(--bs-gray-200);
 }
 .gantt-days {
   &>div {
@@ -91,44 +100,21 @@ main:has(.gantt-chart) {
   }
 }
 .weekend {
-  @extend .bg-secondary;
-  @extend .bg-opacity-10;
+  background-color: var(--bs-gray-200);
 }
 .gantt-body {
   @extend .d-grid;
 
   &>div {
     grid-area: 1 / 1;
+    z-index: 1;
   }
 }
-.vertical-lines {
-  .gantt-timeline-row>div:not(:last-child) {
-    border-right: 1px dotted var(--bs-gray-300);
-  }
-  .today {
-    @extend .position-relative;
-
-    &::after {
-      @extend .bg-danger;
-      @extend .position-absolute;
-      @extend .start-0;
-      @extend .end-0;
-      @extend .my-0;
-      @extend .mx-auto;
-      @extend .h-100;
-      @extend .d-block;
-      content: "";
-      width: 1px;
-      z-index: 2;
-    }
-  }
+.vertical-lines .gantt-timeline-row>div:not(:last-child) {
+  border-right: 1px dotted var(--bs-gray-300);
 }
-.gantt-tasks .gantt-row:nth-child(odd) {
-  .gantt-timeline-row,
-  .gantt-task-content {
-    @extend .bg-secondary;
-    @extend .bg-opacity-10;
-  }
+.gantt-tasks .gantt-timeline-row>div {
+  grid-row: 1;
 }
 .gantt-bar {
   @extend .bg-primary;
@@ -137,13 +123,28 @@ main:has(.gantt-chart) {
   @extend .h-75;
   @extend .my-auto;
   @extend .mx-0;
-  z-index: 1;
 }
 .done-task {
   .gantt-task-content {
     @extend .text-black-50;
+    @extend .text-decoration-line-through;
   }
   .gantt-bar {
     @extend .bg-secondary;
+  }
+}
+.today-line {
+  @extend .position-relative;
+  @extend .d-grid;
+  place-items: center;
+  margin-right: 1px;
+  margin-bottom: -1px;
+
+  &::after {
+    @extend .bg-danger;
+    @extend .position-absolute;
+    @extend .h-100;
+    content: "";
+    width: 1px;
   }
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,6 +21,12 @@ class ApplicationController < ActionController::Base
     redirect_to new_organization_path if current_user.organization.blank?
   end
 
+  def block_user_belongs_to_other_organization(requested_object)
+    if requested_object.organization != current_user.organization
+      redirect_to projects_path
+    end
+  end
+
   def set_my_projects
     @my_projects = current_user.projects.not_archived.descend_by_updated_at
   end

--- a/app/controllers/tasks/sortings_controller.rb
+++ b/app/controllers/tasks/sortings_controller.rb
@@ -1,0 +1,13 @@
+class Tasks::SortingsController < ApplicationController
+  before_action :set_task, only: :update
+  before_action -> { block_user_belongs_to_other_organization(@task) }
+
+  def update
+    @task.update(row_order_position: params[:row_order_position])
+    head :no_content
+  end
+
+  def set_task
+    @task = Task.find(params[:id])
+  end
+end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,5 +1,6 @@
 class TasksController < ApplicationController
   before_action :set_project, only: %w(index new create)
+  before_action :set_task, only: %w(show edit update destroy)
   before_action -> {
     requested_object = @project || @task
     block_user_belongs_to_other_organization(requested_object)
@@ -30,10 +31,17 @@ class TasksController < ApplicationController
     end
   end
 
+  def show
+  end
+
   private
 
   def set_project
     @project = Project.find(params[:project_id])
+  end
+
+  def set_task
+    @task = Task.find(params[:id])
   end
 
   def create_timeline_dates(base_date, half_time_span_year)

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -10,7 +10,7 @@ class TasksController < ApplicationController
     @tasks = @project.tasks.rank(:row_order)
 
     today = Time.zone.today
-    @timeline_dates = create_timeline_dates(today, 3)
+    @timeline_dates = create_timeline_dates(today, 1)
     @today_grid_column = @timeline_dates.find_index(today) + 1
   end
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -4,8 +4,9 @@ class TasksController < ApplicationController
   def index
     @tasks = @project.tasks.rank(:row_order)
 
-    @today = Time.zone.today
-    @timeline_dates = create_timeline_dates(@today, 3)
+    today = Time.zone.today
+    @timeline_dates = create_timeline_dates(today, 3)
+    @today_grid_column = @timeline_dates.find_index(today) + 1
   end
 
   def new

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,5 +1,9 @@
 class TasksController < ApplicationController
-  before_action :block_user_belongs_to_other_organization
+  before_action :set_project, only: %w(index new create)
+  before_action -> {
+    requested_object = @project || @task
+    block_user_belongs_to_other_organization(requested_object)
+  }
 
   def index
     @tasks = @project.tasks.rank(:row_order)
@@ -28,13 +32,8 @@ class TasksController < ApplicationController
 
   private
 
-  def block_user_belongs_to_other_organization
-    if action_name.start_with?(*%w(index new create))
-      @project = Project.find(params[:project_id])
-      if @project.organization != current_user.organization
-        redirect_to projects_path
-      end
-    end
+  def set_project
+    @project = Project.find(params[:project_id])
   end
 
   def create_timeline_dates(base_date, half_time_span_year)

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :block_user_belongs_to_other_organization
 
   def index
-    @tasks = @project.tasks.order(:row_order)
+    @tasks = @project.tasks.rank(:row_order)
 
     @today = Time.zone.today
     @timeline_dates = create_timeline_dates(@today, 3)

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -19,9 +19,7 @@ class TasksController < ApplicationController
   end
 
   def create
-    @task = @project.tasks.new(
-      params.require(:task).permit(:name, :start_at, :end_at, :description)
-    )
+    @task = @project.tasks.new(task_params)
     if @task.save
       flash[:notice] = 'タスクを作成しました。'
       redirect_to project_tasks_path(@project)
@@ -32,6 +30,19 @@ class TasksController < ApplicationController
   end
 
   def show
+  end
+
+  def edit
+  end
+
+  def update
+    if @task.update(task_params)
+      flash[:notice] = 'タスク情報を更新しました。'
+      redirect_to project_tasks_path(@task.project)
+    else
+      flash.now[:alert] = 'タスク情報を更新できませんでした。'
+      render 'edit', status: :unprocessable_entity
+    end
   end
 
   private
@@ -48,5 +59,9 @@ class TasksController < ApplicationController
     start_date = base_date.years_ago(half_time_span_year).beginning_of_month
     end_date = base_date.years_since(half_time_span_year).end_of_month
     (start_date..end_date).to_a
+  end
+
+  def task_params
+    params.require(:task).permit(:name, :start_at, :end_at, :description, :is_done)
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -4,3 +4,4 @@
 import "@hotwired/turbo-rails"
 import "controllers"
 import "sortablejs"
+import "@rails/request.js"

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,3 +3,4 @@
 //= require bootstrap-sprockets
 import "@hotwired/turbo-rails"
 import "controllers"
+import "sortablejs"

--- a/app/javascript/controllers/sortable_controller.js
+++ b/app/javascript/controllers/sortable_controller.js
@@ -1,0 +1,11 @@
+import { Controller } from "@hotwired/stimulus"
+import { Sortable } from "sortablejs"
+
+export default class extends Controller {
+
+  connect() {
+    Sortable.create(this.element, {
+      animation: 150,
+    });
+  }
+}

--- a/app/javascript/controllers/sortable_controller.js
+++ b/app/javascript/controllers/sortable_controller.js
@@ -1,11 +1,27 @@
 import { Controller } from "@hotwired/stimulus"
 import { Sortable } from "sortablejs"
+import { patch } from '@rails/request.js'
 
 export default class extends Controller {
+  static values = { url: String };
 
   connect() {
-    Sortable.create(this.element, {
+    this.sortable = Sortable.create(this.element, {
       animation: 150,
+      onEnd: this.onEnd.bind(this),
+    });
+  }
+
+  disconnect() {
+    this.sortable.destroy();
+  }
+
+  onEnd(event) {
+    const { newIndex, item } = event;
+    const id = item.dataset.sortableId;
+    const url = this.urlValue.replace(":id", id);
+    patch(url, {
+      body: JSON.stringify({ row_order_position: newIndex }),
     });
   }
 }

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -11,6 +11,10 @@ class Task < ApplicationRecord
 
   delegate :organization, to: :project
 
+  def display_done_state
+    is_done ? '完了' : '未完了'
+  end
+
   private
 
   def check_period

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -9,6 +9,8 @@ class Task < ApplicationRecord
   validate :check_period
   validates :is_done, inclusion: [true, false]
 
+  delegate :organization, to: :project
+
   private
 
   def check_period

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,0 +1,31 @@
+<div class="container">
+  <h1 class="mt-5">タスク編集</h1>
+  <%= form_with model: @task do |f| %>
+    <%= render "shared/error_messages", object: @task %>
+    <div>
+      <%= f.label :name %>
+      <span class="badge bg-danger">必須</span><br>
+      <%= f.text_field :name, autofocus: true %>
+    </div>
+    <div>
+      <%= f.label :start_at %><br>
+      <%= f.date_field :start_at %>
+    </div>
+    <div>
+      <%= f.label :end_at %><br>
+      <%= f.date_field :end_at %>
+    </div>
+    <div>
+      <%= f.label :description %><br>
+      <%= f.text_area :description %>
+    </div>
+    <div>
+      <%= f.label :is_done %><br>
+      <%= f.check_box :is_done %>
+    </div>
+    <div>
+      <%= f.submit "保存" %>
+    </div>
+  <% end %>
+  <%= link_to "キャンセル", 'javascript:history.back()' %>
+</div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -32,9 +32,9 @@
           </div>
           <div class="gantt-days gantt-timeline-row">
             <% @timeline_dates.each.with_index(1) do |date, column| %>
-              <div class="<%= "today" if date == @today %><%= " weekend" if weekend?(date) %>"
+              <div class="<%= "today" if column == @today_grid_column %><%= " weekend" if weekend?(date) %>"
                    style="grid-column: <%= column %>;"
-                   data-gantt-chart-target="<%= "today" if date == @today %>">
+                   data-gantt-chart-target="<%= "today" if column == @today_grid_column %>">
                 <%= date.day %>
                 <br>
                 <%= date.to_fs(:japanese_day_of_week) %>
@@ -48,7 +48,7 @@
           <div class="gantt-task-content"></div>
           <div class="gantt-timeline-row">
             <% @timeline_dates.each.with_index(1) do |date, column| %>
-              <div class="<%= "today" if date == @today %><%= " weekend" if weekend?(date) %>" style="grid-column: <%= column %>;"></div>
+              <div class="<%= " weekend" if weekend?(date) %>" style="grid-column: <%= column %>;"></div>
             <% end %>
           </div>
         </div>
@@ -65,6 +65,7 @@
                 <div class="gantt-bar"
                      style="<%= calculate_grid_column(@timeline_dates, task.start_at, task.end_at) %>"
                 ></div>
+                <div class="today-line" style="grid-column: <%= @today_grid_column %>;"></div>
               </div>
             </div>
           <% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -59,8 +59,8 @@
                 <div class="gantt-task-content">
                   <div><%= task.name %></div>
                   <div></div>
-                  <div><%= task.start_at.to_fs(:date) if task.start_at.present? %></div>
-                  <div><%= task.end_at.to_fs(:date) if task.end_at.present? %></div>
+                  <div><%= task.start_at&.to_fs(:date) %></div>
+                  <div><%= task.end_at&.to_fs(:date) %></div>
                 </div>
                 <div class="gantt-timeline-row">
                   <div class="gantt-bar"

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -52,7 +52,7 @@
             <% end %>
           </div>
         </div>
-        <div class="gantt-tasks">
+        <div class="gantt-tasks" data-controller="sortable">
           <% @tasks.each do |task| %>
             <div class="gantt-row <%= "done-task" if task.is_done %>">
               <div class="gantt-task-content">

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -54,20 +54,22 @@
         </div>
         <div class="gantt-tasks" data-controller="sortable" data-sortable-url-value="<%= tasks_sorting_path(id: ':id') %>">
           <% @tasks.each do |task| %>
-            <div class="gantt-row <%= "done-task" if task.is_done %>" data-sortable-id="<%= task.id %>">
-              <div class="gantt-task-content">
-                <div><%= task.name %></div>
-                <div></div>
-                <div><%= task.start_at.to_fs(:date) if task.start_at.present? %></div>
-                <div><%= task.end_at.to_fs(:date) if task.end_at.present? %></div>
+            <%= link_to task_path(task), class: "text-decoration-none text-dark", data: { sortable_id: task.id } do %>
+              <div class="gantt-row <%= "done-task" if task.is_done %>">
+                <div class="gantt-task-content">
+                  <div><%= task.name %></div>
+                  <div></div>
+                  <div><%= task.start_at.to_fs(:date) if task.start_at.present? %></div>
+                  <div><%= task.end_at.to_fs(:date) if task.end_at.present? %></div>
+                </div>
+                <div class="gantt-timeline-row">
+                  <div class="gantt-bar"
+                      style="<%= calculate_grid_column(@timeline_dates, task.start_at, task.end_at) %>"
+                  ></div>
+                  <div class="today-line" style="grid-column: <%= @today_grid_column %>;"></div>
+                </div>
               </div>
-              <div class="gantt-timeline-row">
-                <div class="gantt-bar"
-                     style="<%= calculate_grid_column(@timeline_dates, task.start_at, task.end_at) %>"
-                ></div>
-                <div class="today-line" style="grid-column: <%= @today_grid_column %>;"></div>
-              </div>
-            </div>
+            <% end %>
           <% end %>
         </div>
       </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -52,9 +52,9 @@
             <% end %>
           </div>
         </div>
-        <div class="gantt-tasks" data-controller="sortable">
+        <div class="gantt-tasks" data-controller="sortable" data-sortable-url-value="<%= tasks_sorting_path(id: ':id') %>">
           <% @tasks.each do |task| %>
-            <div class="gantt-row <%= "done-task" if task.is_done %>">
+            <div class="gantt-row <%= "done-task" if task.is_done %>" data-sortable-id="<%= task.id %>">
               <div class="gantt-task-content">
                 <div><%= task.name %></div>
                 <div></div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,0 +1,29 @@
+<div class="container">
+  <h1 class="mt-5 mb-3">タスク詳細</h1>
+  <div>
+    <div class="mb-3">
+      <div class="fw-bold"><%= t('activerecord.attributes.task.name') %></div>
+      <div class="ms-3"><%= @task.name %></div>
+    </div>
+    <div class="mb-3">
+      <div class="fw-bold"><%= t('activerecord.attributes.task.start_at') %></div>
+      <div class="ms-3"><%= @task.start_at&.to_fs(:date) %></div>
+    </div>
+    <div class="mb-3">
+      <div class="fw-bold"><%= t('activerecord.attributes.task.end_at') %></div>
+      <div class="ms-3"><%= @task.end_at&.to_fs(:date) %></div>
+    </div>
+    <div class="mb-3">
+      <div class="fw-bold"><%= t('activerecord.attributes.task.description') %></div>
+      <div class="ms-3"><%= @task.description %></div>
+    </div>
+    <div class="mb-3">
+      <div class="fw-bold"><%= t('activerecord.attributes.task.is_done') %></div>
+      <div class="ms-3"><%= @task.display_done_state %></div>
+    </div>
+  </div>
+  <div>
+    <div><%= link_to "編集", "#" %></div>
+    <div><%= link_to "戻る", 'javascript:history.back()' %></div>
+  </div>
+</div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -23,7 +23,7 @@
     </div>
   </div>
   <div>
-    <div><%= link_to "編集", "#" %></div>
+    <div><%= link_to "編集", edit_task_path(@task) %></div>
     <div><%= link_to "戻る", 'javascript:history.back()' %></div>
   </div>
 </div>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -7,3 +7,4 @@ pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "bootstrap", to: "bootstrap.min.js", preload: true
 pin "@popperjs/core", to: "popper.js", preload: true
+pin "sortablejs", to: "https://ga.jspm.io/npm:sortablejs@1.15.0/modular/sortable.esm.js"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -18,7 +18,7 @@ ja:
         start_at: 開始日
         end_at: 終了日
         description: 説明
-        is_done: 完了
+        is_done: 完了状態
         row_order: ソート順序
   attributes:
     created_at: 作成日時

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -19,7 +19,7 @@ ja:
         end_at: 終了日
         description: 説明
         is_done: 完了
-        row_order: 行の順番
+        row_order: ソート順序
   attributes:
     created_at: 作成日時
     updated_at: 更新日時

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,9 @@ Rails.application.routes.draw do
       resources :archived, only: :index
     end
     resources :projects do
+      namespace :tasks do
+        resources :sortings, only: :update
+      end
       resources :tasks
     end
   end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -12,6 +12,10 @@ FactoryBot.define do
       is_done { true }
     end
 
+    factory :custom_task do
+      name { 'custom task' }
+    end
+
     factory :task_with_time_span do
       start_at { Time.zone.now }
       end_at { start_at }

--- a/spec/requests/tasks/sortings_spec.rb
+++ b/spec/requests/tasks/sortings_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe "Tasks::Sortings", type: :request do
+  let(:user) { create(:user) }
+
+  before { sign_in user }
+
+  describe "PATCH /tasks/sortings/:id" do
+    context 'ユーザーが組織に所属している場合' do
+      let(:project) { create(:project) }
+
+      before { project.organization.users << user }
+
+      context '所属組織のタスクの場合' do
+        let!(:task) { create(:task, project: project) }
+
+        before { create_list(:task, 3, project: task.project) }
+
+        context '有効な属性値の場合' do
+          let(:new_row_order) { 2 }
+
+          it 'ソート順の値を更新できること' do
+            expect do
+              patch tasks_sorting_path(task), params: { row_order_position: new_row_order }
+            end.to change { task.reload.row_order_rank }.from(0).to(new_row_order)
+            expect(response).to have_http_status :no_content
+          end
+        end
+
+        context '無効な属性値の場合' do
+          let(:new_row_order) { nil }
+
+          it 'ソート順の値を更新できないこと' do
+            expect do
+              patch tasks_sorting_path(task), params: { row_order_position: new_row_order }
+            end.not_to change { task.reload.row_order_rank }.from(0)
+            expect(response).to have_http_status :no_content
+          end
+        end
+      end
+
+      context '他の組織のタスクの場合' do
+        let!(:task) { create(:task) }
+        let(:new_row_order) { 2 }
+
+        before { create_list(:task, 3, project: task.project) }
+
+        it 'ソート順の値を更新できず、プロジェクト一覧ページにリダイレクトされること' do
+          expect do
+            patch tasks_sorting_path(task), params: { row_order_position: new_row_order }
+          end.not_to change { task.reload.row_order_rank }.from(0)
+          expect(response).to redirect_to projects_path
+        end
+      end
+    end
+
+    context 'ユーザーが組織に所属していない場合' do
+      let!(:task) { create(:task) }
+      let(:new_row_order) { 2 }
+
+      before { create_list(:task, 3, project: task.project) }
+
+      it 'ソート順の値を更新できず、組織作成ページにリダイレクトされること' do
+        expect do
+          patch tasks_sorting_path(task), params: { row_order_position: new_row_order }
+        end.not_to change { task.reload.row_order_rank }.from(0)
+        expect(response).to redirect_to new_organization_path
+      end
+    end
+  end
+end

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -125,4 +125,43 @@ RSpec.describe "Tasks", type: :request do
       end
     end
   end
+
+  describe "GET /tasks/:id" do
+    context 'ユーザーが組織に所属している場合' do
+      let(:project) { create(:project) }
+
+      before { project.organization.users << user }
+
+      context '所属組織のタスクの場合' do
+        let(:task) { create(:task, project: project) }
+
+        before { get task_path(task) }
+
+        it 'タスク情報を取得できること' do
+          expect(response.body).to include task.name
+          expect(response).to have_http_status 200
+        end
+      end
+
+      context '他の組織のタスクの場合' do
+        let(:task) { create(:task) }
+
+        before { get task_path(task) }
+
+        it 'プロジェクト一覧ページにリダイレクトされること' do
+          expect(response).to redirect_to projects_path
+        end
+      end
+    end
+
+    context 'ユーザーが組織に所属していない場合' do
+      let(:task) { create(:task) }
+
+      before { get task_path(task) }
+
+      it '組織作成ページにリダイレクトされること' do
+        expect(response).to redirect_to new_organization_path
+      end
+    end
+  end
 end

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -164,4 +164,61 @@ RSpec.describe "Tasks", type: :request do
       end
     end
   end
+
+  describe "PATCH /tasks/:id" do
+    context 'ユーザーが組織に所属している場合' do
+      let(:project) { create(:project) }
+
+      before { project.organization.users << user }
+
+      context '所属組織のタスクの場合' do
+        let(:task) { create(:task, project: project) }
+
+        context '有効な属性値の場合' do
+          let(:task_attributes) { attributes_for(:custom_task) }
+
+          it 'タスク情報を更新できること' do
+            expect do
+              patch task_path(task), params: { task: task_attributes }
+            end.to change { task.reload.name }.from(task.name).to(task_attributes[:name])
+          end
+        end
+
+        context '無効な属性値の場合' do
+          let(:task_attributes) { attributes_for(:custom_task, :invalid) }
+
+          it 'タスク情報を更新できないこと' do
+            expect do
+              patch task_path(task), params: { task: task_attributes }
+            end.not_to change { task.reload.name }
+            expect(response).to have_http_status :unprocessable_entity
+          end
+        end
+      end
+
+      context '他の組織のタスクの場合' do
+        let(:task) { create(:task) }
+        let(:task_attributes) { attributes_for(:custom_task) }
+
+        it 'タスク情報が更新されず、プロジェクト一覧ページにリダイレクトされること' do
+          expect do
+            patch task_path(task), params: { task: task_attributes }
+          end.not_to change { task.reload.name }
+          expect(response).to redirect_to projects_path
+        end
+      end
+    end
+
+    context 'ユーザーが組織に所属していない場合' do
+      let(:task) { create(:task) }
+      let(:task_attributes) { attributes_for(:custom_task) }
+
+      it 'タスク情報が更新されず、組織作成ページにリダイレクトされること' do
+        expect do
+          patch task_path(task), params: { task: task_attributes }
+        end.not_to change { task.reload.name }
+        expect(response).to redirect_to new_organization_path
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Issue または変更目的
close #26 

## 変更内容
- [x] ドラッグアンドドロップによる、タスク並べ替え機能の追加。
- [x] タスク詳細表示機能の追加。
- [x] タスク編集機能の追加。

## 確認手順
<!--仕様やテストがあるならその旨を記載すれば十分-->
下記の点以外はテストを参照のこと。
- [x] ドラッグアンドドロップによるタスクの並び替え
   1. `/projects/:project_id/tasks`にアクセスする。
   2. タスクをドラッグアンドドロップで並び替える。
   3. リロードし、並び替えた状態が保存されていることを確認する。
