### PR TITLE
タスク担当者機能の追加

### DIFF
--- a/app/assets/stylesheets/custom/gantt_chart.scss
+++ b/app/assets/stylesheets/custom/gantt_chart.scss
@@ -43,6 +43,7 @@ main:has(.gantt-chart) {
   &>div {
     @extend .d-grid;
     @extend .p-1;
+    @extend .text-center;
     place-items: center;
 
     &:not(:last-child) {

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -7,7 +7,7 @@ class TasksController < ApplicationController
   }
 
   def index
-    @tasks = @project.tasks.rank(:row_order)
+    @tasks = @project.tasks.includes(:users).rank(:row_order)
 
     today = Time.zone.today
     @timeline_dates = create_timeline_dates(today, 1)

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -16,6 +16,7 @@ class TasksController < ApplicationController
 
   def new
     @task = @project.tasks.new
+    @project_members = @project.users
   end
 
   def create
@@ -25,6 +26,7 @@ class TasksController < ApplicationController
       redirect_to project_tasks_path(@project)
     else
       flash.now[:alert] = 'タスクを作成できませんでした。'
+      @project_members = @project.users
       render 'new', status: :unprocessable_entity
     end
   end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -30,6 +30,7 @@ class TasksController < ApplicationController
   end
 
   def show
+    @task_staffs = @task.users
   end
 
   def edit

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -34,6 +34,7 @@ class TasksController < ApplicationController
   end
 
   def edit
+    @project_members = @task.project.users
   end
 
   def update
@@ -42,6 +43,7 @@ class TasksController < ApplicationController
       redirect_to project_tasks_path(@task.project)
     else
       flash.now[:alert] = 'タスク情報を更新できませんでした。'
+      @project_members = @task.project.users
       render 'edit', status: :unprocessable_entity
     end
   end
@@ -63,6 +65,6 @@ class TasksController < ApplicationController
   end
 
   def task_params
-    params.require(:task).permit(:name, :start_at, :end_at, :description, :is_done)
+    params.require(:task).permit(:name, :start_at, :end_at, :description, :is_done, user_ids: [])
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -7,6 +7,7 @@ class Task < ApplicationRecord
 
   has_many :task_staffs, dependent: :destroy
   has_many :users, through: :task_staffs
+  validates :user_ids, inclusion: { in: ->(task) { task.project.user_ids } }
 
   validates :name, presence: true
   validate :check_period

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -5,6 +5,9 @@ class Task < ApplicationRecord
   ranks :row_order,
     with_same: :project_id # projectごとにscopeを絞ってランク付け
 
+  has_many :task_staffs, dependent: :destroy
+  has_many :users, through: :task_staffs
+
   validates :name, presence: true
   validate :check_period
   validates :is_done, inclusion: [true, false]

--- a/app/models/task_staff.rb
+++ b/app/models/task_staff.rb
@@ -1,0 +1,6 @@
+class TaskStaff < ApplicationRecord
+  belongs_to :task
+  belongs_to :user
+
+  validates :task_id, uniqueness: { scope: :user_id }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,9 @@ class User < ApplicationRecord
   has_many :project_members, dependent: :destroy
   has_many :projects, through: :project_members
 
+  has_many :task_staffs, dependent: :destroy
+  has_many :tasks, through: :task_staffs
+
   validates :name, presence: true
 
   # Include default devise modules. Others available are:

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -24,6 +24,12 @@
       <%= f.check_box :is_done %>
     </div>
     <div>
+      <%= f.label :users %><br>
+      <%= f.collection_check_boxes :user_ids, @project_members, :id, :name do |b| %>
+        <%= b.label(class: 'me-3') { b.check_box + b.text } %>
+      <% end %>
+    </div>
+    <div>
       <%= f.submit "保存" %>
     </div>
   <% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -17,7 +17,7 @@
             <%= link_to "+", new_project_task_path,
                 class: 'btn btn-primary position-absolute bottom-0 end-0 mb-1 me-1 px-2 py-0' %>
           </div>
-          <div>担当者</div>
+          <div><%= t('activerecord.attributes.task.users') %></div>
           <div><%= t('activerecord.attributes.task.start_at') %></div>
           <div><%= t('activerecord.attributes.task.end_at') %></div>
         </div>
@@ -58,7 +58,11 @@
               <div class="gantt-row <%= "done-task" if task.is_done %>">
                 <div class="gantt-task-content">
                   <div><%= task.name %></div>
-                  <div></div>
+                  <div>
+                    <% task.users.each do |user| %>
+                      <%= user.name %><br>
+                    <% end %>
+                  </div>
                   <div><%= task.start_at&.to_fs(:date) %></div>
                   <div><%= task.end_at&.to_fs(:date) %></div>
                 </div>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -20,6 +20,12 @@
       <%= f.text_area :description %>
     </div>
     <div>
+      <%= f.label :users %><br>
+      <%= f.collection_check_boxes :user_ids, @project_members, :id, :name do |b| %>
+        <%= b.label(class: 'me-3') { b.check_box + b.text } %>
+      <% end %>
+    </div>
+    <div>
       <%= f.submit "作成" %>
     </div>
   <% end %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -21,6 +21,15 @@
       <div class="fw-bold"><%= t('activerecord.attributes.task.is_done') %></div>
       <div class="ms-3"><%= @task.display_done_state %></div>
     </div>
+    <div class="mb-3 section-users">
+      <div class="fw-bold"><%= t('activerecord.attributes.task.users') %></div>
+      <div class="ms-3">
+        <% @task_staffs.each_with_index do |user, i| %>
+          <%= "、" if !i.zero? %>
+          <%= user.name %>
+        <% end %>
+      </div>
+    </div>
   </div>
   <div>
     <div><%= link_to "編集", edit_task_path(@task) %></div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -20,6 +20,7 @@ ja:
         description: 説明
         is_done: 完了状態
         row_order: ソート順序
+        users: 担当者
   attributes:
     created_at: 作成日時
     updated_at: 更新日時

--- a/db/migrate/20231006054448_create_task_staffs.rb
+++ b/db/migrate/20231006054448_create_task_staffs.rb
@@ -1,0 +1,12 @@
+class CreateTaskStaffs < ActiveRecord::Migration[7.0]
+  def change
+    create_table :task_staffs do |t|
+      t.integer :task_id
+      t.integer :user_id
+
+      t.timestamps
+    end
+
+    add_index :task_staffs, %i(task_id user_id), unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_28_121043) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_06_054448) do
   create_table "organizations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
@@ -33,6 +33,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_28_121043) do
     t.boolean "is_archived", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "task_staffs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "task_id"
+    t.integer "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["task_id", "user_id"], name: "index_task_staffs_on_task_id_and_user_id", unique: true
   end
 
   create_table "tasks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -160,6 +160,7 @@ product_development_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(1),
   description: '筐体と機構を優先すること。',
   is_done: true,
+  users: [sato_user, alice_user, bob_user],
 )
 product_development_project.tasks.create!(
   name: '図面作成',
@@ -167,6 +168,7 @@ product_development_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_since(1),
   description: '',
   is_done: false,
+  users: [alice_user, bob_user],
 )
 product_development_project.tasks.create!(
   name: '部品手配',
@@ -174,6 +176,7 @@ product_development_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_since(1),
   description: '4台分手配。手配可能なものがあれば順次手配する。',
   is_done: false,
+  users: [alice_user, bob_user],
 )
 product_development_project.tasks.create!(
   name: '組立',
@@ -181,6 +184,7 @@ product_development_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_since(7),
   description: '',
   is_done: false,
+  users: [alice_user, bob_user],
 )
 product_development_project.tasks.create!(
   name: '設計検証',
@@ -188,6 +192,7 @@ product_development_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_since(11),
   description: '',
   is_done: false,
+  users: [sato_user, alice_user, bob_user],
 )
 product_development_project.tasks.create!(
   name: 'QAへの入検',
@@ -195,6 +200,7 @@ product_development_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_since(15),
   description: '',
   is_done: false,
+  users: [sato_user, alice_user, bob_user],
 )
 
 safety_regulations_project.tasks.create!(
@@ -203,6 +209,7 @@ safety_regulations_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(8),
   description: '',
   is_done: true,
+  users: [sato_user],
 )
 safety_regulations_project.tasks.create!(
   name: '3Dモデル設計',
@@ -210,6 +217,7 @@ safety_regulations_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(6),
   description: '',
   is_done: true,
+  users: [alice_user],
 )
 safety_regulations_project.tasks.create!(
   name: '図面作成',
@@ -217,6 +225,7 @@ safety_regulations_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(5),
   description: '',
   is_done: true,
+  users: [alice_user],
 )
 safety_regulations_project.tasks.create!(
   name: '部品手配',
@@ -224,6 +233,7 @@ safety_regulations_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(5),
   description: '',
   is_done: true,
+  users: [alice_user],
 )
 safety_regulations_project.tasks.create!(
   name: '設計検証',
@@ -231,6 +241,7 @@ safety_regulations_project.tasks.create!(
   end_at: THIS_FRIDAY,
   description: '',
   is_done: false,
+  users: [alice_user],
 )
 safety_regulations_project.tasks.create!(
   name: 'QAへの入検',
@@ -238,6 +249,7 @@ safety_regulations_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_since(1),
   description: '',
   is_done: false,
+  users: [alice_user],
 )
 safety_regulations_project.tasks.create!(
   name: '変更連絡書の発行',
@@ -245,6 +257,7 @@ safety_regulations_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_since(3),
   description: '',
   is_done: false,
+  users: [alice_user],
 )
 
 cable_disconnection_project.tasks.create!(
@@ -253,6 +266,7 @@ cable_disconnection_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(14),
   description: '',
   is_done: true,
+  users: [suzuki_user, hoshino_user],
 )
 cable_disconnection_project.tasks.create!(
   name: '試作手配',
@@ -260,6 +274,7 @@ cable_disconnection_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(13),
   description: '',
   is_done: true,
+  users: [hoshino_user],
 )
 cable_disconnection_project.tasks.create!(
   name: '設計検証',
@@ -267,6 +282,7 @@ cable_disconnection_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(6),
   description: '',
   is_done: true,
+  users: [hoshino_user],
 )
 cable_disconnection_project.tasks.create!(
   name: 'QAへの入検',
@@ -274,6 +290,7 @@ cable_disconnection_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(5),
   description: '',
   is_done: true,
+  users: [hoshino_user],
 )
 cable_disconnection_project.tasks.create!(
   name: '変更連絡書の発行',
@@ -281,6 +298,7 @@ cable_disconnection_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(3),
   description: '',
   is_done: true,
+  users: [hoshino_user],
 )
 
 arm_breaking_project.tasks.create!(
@@ -289,6 +307,7 @@ arm_breaking_project.tasks.create!(
   end_at: THIS_FRIDAY,
   description: '',
   is_done: false,
+  users: [suzuki_user, hoshino_user],
 )
 arm_breaking_project.tasks.create!(
   name: '試作手配',
@@ -296,6 +315,7 @@ arm_breaking_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_since(1),
   description: '',
   is_done: false,
+  users: [hoshino_user],
 )
 arm_breaking_project.tasks.create!(
   name: '設計検証',
@@ -303,6 +323,7 @@ arm_breaking_project.tasks.create!(
   end_at: nil,
   description: '',
   is_done: false,
+  users: [hoshino_user],
 )
 arm_breaking_project.tasks.create!(
   name: 'QAへの入検',
@@ -310,6 +331,7 @@ arm_breaking_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_since(12),
   description: '',
   is_done: false,
+  users: [hoshino_user],
 )
 arm_breaking_project.tasks.create!(
   name: '変更連絡書の発行',
@@ -317,6 +339,7 @@ arm_breaking_project.tasks.create!(
   end_at: nil,
   description: '',
   is_done: false,
+  users: [hoshino_user],
 )
 
 sensor_false_detection_project.tasks.create!(
@@ -325,6 +348,7 @@ sensor_false_detection_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(12),
   description: '',
   is_done: true,
+  users: [suzuki_user, saito_user],
 )
 sensor_false_detection_project.tasks.create!(
   name: '試作手配',
@@ -332,6 +356,7 @@ sensor_false_detection_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(11),
   description: '',
   is_done: true,
+  users: [saito_user],
 )
 sensor_false_detection_project.tasks.create!(
   name: '設計検証',
@@ -339,6 +364,7 @@ sensor_false_detection_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(4),
   description: '',
   is_done: true,
+  users: [saito_user],
 )
 sensor_false_detection_project.tasks.create!(
   name: 'QAへの入検',
@@ -346,6 +372,7 @@ sensor_false_detection_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(3),
   description: '',
   is_done: true,
+  users: [saito_user],
 )
 sensor_false_detection_project.tasks.create!(
   name: '変更連絡書の発行',
@@ -353,6 +380,7 @@ sensor_false_detection_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(1),
   description: '',
   is_done: true,
+  users: [saito_user],
 )
 
 # 神奈川製鉄株式会社
@@ -362,6 +390,7 @@ material_research_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_since(8),
   description: '',
   is_done: false,
+  users: [tanaka_user],
 )
 car_frame_project.tasks.create!(
   name: '抗酸化皮膜の耐久試験',
@@ -369,4 +398,5 @@ car_frame_project.tasks.create!(
   end_at: THIS_FRIDAY.weeks_ago(1),
   description: '',
   is_done: true,
+  users: [tanaka_user],
 )

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Task, type: :model do
+  describe 'validation' do
+    let(:project) { create(:project) }
+
+    it 'プロジェクトメンバーだけを許可する' do
+      project_member = create(:user, projects: [project])
+      task = build(:task, project: project, users: [project_member])
+      expect(task).to be_valid
+
+      not_project_member = create(:user)
+      task.users = [not_project_member]
+      expect(task).to be_invalid
+    end
+  end
+end

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe "Tasks", type: :request do
 
   describe "PATCH /tasks/:id" do
     context 'ユーザーが組織に所属している場合' do
-      let(:project) { create(:project) }
+      let(:project) { create(:project, users: [user]) }
 
       before { project.organization.users << user }
 
@@ -181,6 +181,12 @@ RSpec.describe "Tasks", type: :request do
             expect do
               patch task_path(task), params: { task: task_attributes }
             end.to change { task.reload.name }.from(task.name).to(task_attributes[:name])
+          end
+
+          it '担当者を更新できること' do
+            expect do
+              patch task_path(task), params: { task: task_attributes.merge(user_ids: [user.id]) }
+            end.to change { task.reload.user_ids }.from([]).to([user.id])
           end
         end
 

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "Tasks", type: :request do
       let!(:organization) { create(:organization, users: [user]) }
 
       context '所属組織のプロジェクトの場合' do
-        let(:project) { create(:project, organization: organization) }
+        let(:project) { create(:project, organization: organization, users: [user]) }
 
         context '有効な属性値の場合' do
           let(:task_attributes) { attributes_for(:task) }
@@ -85,6 +85,14 @@ RSpec.describe "Tasks", type: :request do
               post project_tasks_path(project), params: { task: task_attributes }
             end.to change { project.tasks.count }.by(1)
             expect(project.tasks.last.row_order).to be_truthy
+          end
+
+          it '担当者を登録できること' do
+            post(
+              project_tasks_path(project),
+              params: { task: task_attributes.merge(user_ids: [user.id]) }
+            )
+            expect(project.tasks.last.user_ids).to eq [user.id]
           end
         end
 

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -21,6 +21,18 @@ RSpec.describe 'Tasks', type: :system do
     end
 
     describe 'タスク' do
+      describe 'タスク情報' do
+        let!(:task) { create(:task, project: project, users: [user]) }
+
+        before { visit project_tasks_path(project) }
+
+        it '担当者が表示されていること' do
+          within '.gantt-tasks .gantt-task-content' do
+            expect(page).to have_content user.name
+          end
+        end
+      end
+
       describe 'ガントバー' do
         context 'タスク期間が指定されている場合' do
           let!(:task) { create(:task_with_time_span, project: project) }

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -69,6 +69,20 @@ RSpec.describe 'Tasks', type: :system do
     end
   end
 
+  describe 'タスク詳細ページ' do
+    let(:task) { create(:task, users: [user]) }
+
+    before { task.organization.users << user }
+
+    it '担当者が表示されていること' do
+      visit task_path(task)
+
+      within '.section-users' do
+        expect(page).to have_content user.name
+      end
+    end
+  end
+
   describe 'タスク登録機能' do
     let(:project) { create(:project) }
     let(:task) { build(:task) }

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -22,11 +22,16 @@ RSpec.describe 'Tasks', type: :system do
 
     describe 'タスク' do
       describe 'タスク情報' do
-        let!(:task) { create(:task, project: project, users: [user]) }
+        let!(:task) { create(:task, project: project) }
 
-        before { visit project_tasks_path(project) }
+        before do
+          project.users << user
+          task.users << user
+        end
 
         it '担当者が表示されていること' do
+          visit project_tasks_path(project)
+
           within '.gantt-tasks .gantt-task-content' do
             expect(page).to have_content user.name
           end
@@ -70,9 +75,13 @@ RSpec.describe 'Tasks', type: :system do
   end
 
   describe 'タスク詳細ページ' do
-    let(:task) { create(:task, users: [user]) }
+    let(:task) { create(:task) }
 
-    before { task.organization.users << user }
+    before do
+      task.organization.users << user
+      task.project.users << user
+      task.users << user
+    end
 
     it '担当者が表示されていること' do
       visit task_path(task)


### PR DESCRIPTION
## Issue または変更目的
close #41 

## 変更内容
- [x] タスク担当者モデルを作成する。
- [x] タスク担当者登録機能を追加する。
- [x] タスク担当者編集機能を追加する。
- [x] タスク一覧ページにて、タスク担当者を表示する。
- [x] タスク詳細ページにて、タスク担当者を表示する。
- [x] seedにタスク担当者を追加する。

## 確認手順
<!--仕様やテストがあるならその旨を記載すれば十分-->
テストを参照のこと。
