### PR TITLE
組織メンバー脱退機能の追加

### DIFF
--- a/app/controllers/organizations/members_controller.rb
+++ b/app/controllers/organizations/members_controller.rb
@@ -20,7 +20,11 @@ class Organizations::MembersController < ApplicationController
   end
 
   def destroy
-    @member.update!(organization_id: nil)
+    @member.transaction do
+      @member.update!(organization_id: nil)
+      @member.project_members.map(&:destroy!)
+      @member.task_staffs.map(&:destroy!)
+    end
     flash[:notice] = "#{@member.name}を脱退させました。"
     redirect_to organization_path
   end

--- a/app/controllers/organizations/members_controller.rb
+++ b/app/controllers/organizations/members_controller.rb
@@ -1,7 +1,7 @@
 class Organizations::MembersController < ApplicationController
   before_action :block_normal_user, except: %i(index new show edit)
   before_action :block_myself, except: %i(index new show edit)
-  before_action :set_member, only: %i(show edit update)
+  before_action :set_member, only: %i(show edit update destroy)
 
   def show
   end
@@ -17,6 +17,12 @@ class Organizations::MembersController < ApplicationController
       flash.now[:alert] = '組織メンバーの権限を更新できませんでした。'
       render 'edit', status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @member.update!(organization_id: nil)
+    flash[:notice] = "#{@member.name}を脱退させました。"
+    redirect_to organization_path
   end
 
   private

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -39,7 +39,7 @@ class OrganizationsController < ApplicationController
   def destroy
     @organization.transaction do
       @organization.users = []
-      @organization.destroy
+      @organization.destroy!
     end
     flash[:notice] = '組織を削除しました。'
     redirect_to new_organization_path

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -7,7 +7,7 @@ class Users::RegistrationsController < DeviseInvitable::RegistrationsController
       if organization && user.is_admin? && organization.reload.users.where(is_admin: true).blank?
         organization.transaction do
           organization.users = []
-          organization.destroy
+          organization.destroy!
         end
       end
     end

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -36,11 +36,14 @@
     <ul class="container mt-3 mb-0">
       <% @members.each.with_index(1) do |member, i| %>
         <li class="row p-2 <%= "border-bottom" unless i == @members.length %>">
-          <div class="col"><%= member.name %></div>
-          <div class="col"><%= member.display_admin_privilege %></div>
-          <div class="col">
+          <div class="col d-flex align-items-center"><%= member.name %></div>
+          <div class="col d-flex align-items-center"><%= member.display_admin_privilege %></div>
+          <div class="col d-flex align-items-center">
             <% unless member == current_user %>
               <%= link_to "詳細", organizations_member_path(member) %>
+              <% if current_user.is_admin? %>
+                <%= button_to '脱退', organizations_member_path(member), data: { turbo_confirm: '本当によろしいですか？' }, method: :delete, class: 'btn btn-danger btn-sm ms-1' %>
+              <% end %>
             <% end %>
           </div>
         </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
     end
 
     namespace :organizations do
-      resources :members, only: %i(show edit update)
+      resources :members, only: %i(show edit update destroy)
     end
     resource :organization
 

--- a/spec/requests/organizations/members_spec.rb
+++ b/spec/requests/organizations/members_spec.rb
@@ -164,4 +164,66 @@ RSpec.describe "Organizations::Members", type: :request do
       end
     end
   end
+
+  # destroy
+  describe "DELETE /organizations/members/:id" do
+    context 'ユーザーが組織に所属している場合' do
+      context '管理者の場合' do
+        let!(:organization) { Organization.create_with_admin(attributes_for(:organization), user) }
+
+        context '所属組織の自分以外のメンバーを指定した場合' do
+          let!(:other_user) { create(:user, organization: organization) }
+
+          it '組織メンバーを脱退させられること' do
+            expect do
+              delete organizations_member_path(other_user)
+            end.to change { organization.reload.users.count }.by(-1)
+          end
+        end
+
+        context '自分自身を指定した場合' do
+          it '組織を脱退できず、プロジェクト一覧ページにリダイレクトされること' do
+            expect do
+              delete organizations_member_path(user)
+            end.not_to change { organization.reload.users.count }
+            expect(response).to redirect_to projects_path
+          end
+        end
+
+        context '所属組織のメンバー以外を指定した場合' do
+          let!(:other_user) { create(:user, :with_organization) }
+
+          it 'エラーが発生すること' do
+            expect do
+              delete organizations_member_path(other_user)
+            end.to raise_error ActiveRecord::RecordNotFound
+          end
+        end
+      end
+
+      context '一般ユーザーの場合' do
+        let!(:organization) { create(:organization, users: [user]) }
+        let!(:other_user) { create(:user, organization: organization) }
+
+        it '組織メンバーを脱退させられず、プロジェクト一覧ページにリダイレクトされること' do
+          expect do
+            delete organizations_member_path(other_user)
+          end.not_to change { organization.reload.users.count }
+          expect(response).to redirect_to projects_path
+        end
+      end
+    end
+
+    context 'ユーザーが組織に所属していない場合' do
+      let!(:organization) { create(:organization) }
+      let!(:other_user) { create(:user, organization: organization) }
+
+      it '組織メンバーを脱退させられず、組織作成ページにリダイレクトされること' do
+        expect do
+          delete organizations_member_path(other_user)
+        end.not_to change { organization.reload.users.count }
+        expect(response).to redirect_to new_organization_path
+      end
+    end
+  end
 end

--- a/spec/requests/organizations/members_spec.rb
+++ b/spec/requests/organizations/members_spec.rb
@@ -174,10 +174,27 @@ RSpec.describe "Organizations::Members", type: :request do
         context '所属組織の自分以外のメンバーを指定した場合' do
           let!(:other_user) { create(:user, organization: organization) }
 
+          before do
+            project = create(:project, organization: organization.reload, users: [other_user])
+            create(:task, project: project, users: [other_user])
+          end
+
           it '組織メンバーを脱退させられること' do
             expect do
               delete organizations_member_path(other_user)
             end.to change { organization.reload.users.count }.by(-1)
+          end
+
+          it 'プロジェクトメンバーから情報が削除されること' do
+            expect do
+              delete organizations_member_path(other_user)
+            end.to change { other_user.reload.projects.count }.by(-1)
+          end
+
+          it 'タスク担当者から情報が削除されること' do
+            expect do
+              delete organizations_member_path(other_user)
+            end.to change { other_user.reload.tasks.count }.by(-1)
           end
         end
 


### PR DESCRIPTION
## Issue または変更目的
close #70 

## 変更内容
- [x] 自分以外の組織メンバーの脱退機能の追加（自分を脱退させることは不可とする）

## 確認手順
<!--仕様やテストがあるならその旨を記載すれば十分-->
以下の点以外はテストを参照のこと。

- [x] 画面操作によるメンバーの脱退
